### PR TITLE
Add support for integrated addresses

### DIFF
--- a/docs/functional-tests.md
+++ b/docs/functional-tests.md
@@ -22,7 +22,7 @@ Button copy address | Pop up "Copied!" and address should be copied to clipboard
 Button copy tr. id | Pop up "Copied!" and tr. id should be copied to clipboard.
 Button explore transaction | Trtl explorer opens in default browser with the right transacton.
 Receive trtl | Balance updates automatically and new confirmed transaction added to list previous transactions
-Send TRTL, address diff. than 99 chars | error: address invalid
+Send TRTL, address diff. than 99 chars or 236 chars | error: address invalid
 Send TRTL, address not start by TRTL | error: address invalid
 Send TRTL, amount is 0 or less | error: amount should be greater than 0
 Send TRTL, amount is not a number | error: amount invalid
@@ -30,6 +30,7 @@ Send TRTL, amount + fee is more than available balance | error: available balanc
 Send TRTL, small valid amount | dialog for confirming transfer. After confirmation, popup TRTL sent. amount is received on the other end
 Send TRTL, invalid payment id | error: wrong payment id format
 Send TRTL, valid payment id | popup TRTL sent. amount is received on the other end with correct payment id
+Send TRTL, valid integrated address | popup TRTL sent. amount is received on the other end with correct payment id from integrated address
 select the option local blockchain, restart | local blockchain should still be selected
 Test using the wallet with local blockchain selected | 
 Test using the wallet with remote node selected |

--- a/qml/Wallet.qml
+++ b/qml/Wallet.qml
@@ -635,6 +635,8 @@ Rectangle {
 
                 onTextChanged: {
                     buttonSend.enabled = textInputTransferAmount.text != "" && textInputTransferAddress.text != ""
+                    /* Disable payment ID input if integrated address */
+                    textInputTransferPaymentID.enabled = textInputTransferAmount.text.length != 236
                 }
             }
         }
@@ -948,7 +950,15 @@ Rectangle {
             onClicked: {
                 rectangleTransfer.transferRecipient = textInputTransferAddress.text
                 rectangleTransfer.transferAmount = textInputTransferAmount.text
-                rectangleTransfer.transferPaymentID = textInputTransferPaymentID.text
+                if (textInputTransferPaymentID.enabled)
+                {
+                    rectangleTransfer.transferPaymentID = textInputTransferPaymentID.text
+                }
+                /* Don't add the payment ID if integrated address */
+                else
+                {
+                    rectangleTransfer.transferPaymentID = "";
+                }
                 rectangleTransfer.transferFee = textInputTransferFee.text
                 dialogConfirmTransfer.show(rectangleTransfer.transferRecipient, rectangleTransfer.transferAmount + " TRTL + " + rectangleTransfer.transferFee + " TRTL (fee)", rectangleTransfer.transferPaymentID);
             }

--- a/qml/Wallet.qml
+++ b/qml/Wallet.qml
@@ -636,7 +636,7 @@ Rectangle {
                 onTextChanged: {
                     buttonSend.enabled = textInputTransferAmount.text != "" && textInputTransferAddress.text != ""
                     /* Disable payment ID input if integrated address */
-                    textInputTransferPaymentID.enabled = textInputTransferAmount.text.length != 236
+                    textInputTransferPaymentID.enabled = textInputTransferAddress.text.length != 236
                 }
             }
         }

--- a/walletdmanager/walletdmanager.go
+++ b/walletdmanager/walletdmanager.go
@@ -138,7 +138,7 @@ func SendTransaction(transferAddress string, transferAmountString string, transf
 		return "", errors.New("wallet and/or blockchain not fully synced yet")
 	}
 
-	if !strings.HasPrefix(transferAddress, "TRTL") || len(transferAddress) != 99 {
+	if !strings.HasPrefix(transferAddress, "TRTL") || (len(transferAddress) != 99 && len(transferAddress) != 236) {
 		return "", errors.New("address is invalid")
 	}
 


### PR DESCRIPTION
This is untested. I will test at some point :grimacing: 

Allows 236 char addresses as well as 99 char addresses.
Disables the payment ID input when an integrated address is being used.