### PR TITLE
Update default remote node

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -14,8 +14,8 @@ const (
 	numberTransactionsToDisplay = 20
 
 	// default remote node
-	defaultRemoteDaemonAddress = "public.turtlenode.io"
+	defaultRemoteDaemonAddress = "public.turtlenode.online"
 	defaultRemoteDaemonPort    = "11898"
-	defaultRemoteDaemonName    = "public.turtlenode.io"
+	defaultRemoteDaemonName    = "public.turtlenode.online"
 	defaultRemoteDaemonSSL     = false
 )


### PR DESCRIPTION
The default remote node is often down.
From http://trtl.nodes.pub/, it has an uptime of 0.22850

Compare that to public.turtlenode.online, which has an uptime of 1.00000.
I think this will help give new users a much better experience.

Plus, public.turtlenode.online has a lower fee.